### PR TITLE
fix: allow trusted Microsoft services to bypass storage network rules

### DIFF
--- a/eventdriven.tf
+++ b/eventdriven.tf
@@ -18,6 +18,7 @@ resource "azurerm_storage_account" "current" {
     for_each = var.enforce_storage_network_rules ? [1] : []
     content {
       default_action = "Deny"
+      bypass         = ["AzureServices"]
       ip_rules       = var.firefly_eips
     }
   }

--- a/modules/single_integration/eventdriven.tf
+++ b/modules/single_integration/eventdriven.tf
@@ -18,6 +18,7 @@ resource "azurerm_storage_account" "current" {
     for_each = var.enforce_storage_network_rules ? [1] : []
     content {
       default_action = "Deny"
+      bypass         = ["AzureServices"]
       ip_rules       = var.firefly_eips
     }
   }


### PR DESCRIPTION
## Summary
- Adds `bypass = ["AzureServices"]` to the `network_rules` block on the storage account in both the root module and `single_integration` submodule.

## Problem
When `enforce_storage_network_rules = true`, the storage account firewall is set to `default_action = "Deny"` but no `bypass` is configured. This causes trusted Microsoft services (Event Grid, Azure Monitor, etc.) to be blocked, and security scanners (e.g. Trivy/Aqua AZU-0010) flag it as a HIGH finding.

## Fix
Setting `bypass = ["AzureServices"]` allows trusted Microsoft services to access the storage account while keeping the firewall deny-by-default for everything else. This is required for the event-driven integration to function correctly and resolves the AZU-0010 scan finding.