### PR TITLE
fix(provider): use ~> to enable newer minor versions of azurerm and a…

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "4.19.0"
+      version               = "~> 4.19"
       configuration_aliases = [azurerm.deployment_subscription]
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.53.1"
+      version = "~> 2.53"
     }
   }
 }


### PR DESCRIPTION
…zuread

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure infrastructure provider version constraints to allow compatible patch releases within the 4.19 and 2.53 series.
  * Adjusted provider configuration formatting to reflect the updated declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->