### PR TITLE
INFL-20264: bump azurerm provider pin to 4.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.19.0"
+      version = "4.28.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ provider "azurerm" {
 }
 
 module "firefly_azure" {
-  source  = "github.com/gofireflyio/terraform-firefly-azure-onboarding?ref=v1.6.2"
+  source  = "github.com/gofireflyio/terraform-firefly-azure-onboarding?ref=v1.6.3"
   providers = {
     azurerm.deployment_subscription = azurerm.deployment_subscription
   }
@@ -125,7 +125,7 @@ provider "azurerm" {
 }
 
 module "firefly_azure" {
-  source  = "github.com/gofireflyio/terraform-firefly-azure-onboarding?ref=v1.6.2/modules/single_integration"
+  source  = "github.com/gofireflyio/terraform-firefly-azure-onboarding?ref=v1.6.3/modules/single_integration"
   providers = {
     azurerm.deployment_subscription = azurerm.deployment_subscription
   }

--- a/modules/firefly_azure_integration/locals.tf
+++ b/modules/firefly_azure_integration/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  version = "0.1.0"
+  version = "0.1.1"
 }

--- a/modules/single_integration/modules/firefly_azure_integration/locals.tf
+++ b/modules/single_integration/modules/firefly_azure_integration/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  version = "0.1.0"
+  version = "0.1.1"
 }

--- a/modules/single_integration/providers.tf
+++ b/modules/single_integration/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "4.19.0"
+      version               = "4.28.0"
       configuration_aliases = [azurerm.deployment_subscription]
     }
     azuread = {

--- a/providers.tf
+++ b/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "4.19.0"
+      version               = "4.28.0"
       configuration_aliases = [azurerm.deployment_subscription]
     }
     azuread = {


### PR DESCRIPTION
## Jira
INFL-20264

## Change type
Bug fix (provider version compatibility)

## What changed
Bumped the `hashicorp/azurerm` provider pin from `4.19.0` to `4.28.0` in:
- `providers.tf` (root module)
- `modules/single_integration/providers.tf`
- `README.md` (Required Providers example)

## Why
A customer (Lineal) could not use the `azurerm_function_app_flex_consumption` (Flex Consumption) resource, which requires azurerm `>= 4.28.0`. Because this module **exact-pinned** azurerm to `4.19.0`, Terraform's dependency resolution forced their entire configuration to 4.19.0, producing a version-compatibility conflict.

Pinning to `4.28.0` — the minimum version that supports Flex Consumption — unblocks the customer while keeping the Firefly integration on a single, known-good provider version. `azuread` (2.53.1) is unchanged; it was not part of the conflict.

## Notes
- `4.28.0` is within the azurerm v4 major line, so no breaking provider changes are expected relative to 4.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated Terraform Azure provider version requirement to `4.28.0` (from `4.19.0`) for the root configuration and the single-integration module.
  * Bumped the Azure integration module version from `0.1.0` to `0.1.1`.
* **Documentation**
  * Refreshed README requirements and installation examples to reference the newer Terraform module version (`v1.6.3`) and aligned provider constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->