### PR TITLE
INFL-20461: bump azuread provider from 2.53.1 to 3.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.53.1"
+      version = "3.9.0"
     }
   }
 }

--- a/modules/single_integration/data.tf
+++ b/modules/single_integration/data.tf
@@ -3,7 +3,7 @@ data "azuread_client_config" "current" {}
 
 data "azuread_service_principal" "existing" {
   count = var.existing_service_principal_id != "" ? 1 : 0
-  application_id = var.existing_service_principal_id
+  client_id = var.existing_service_principal_id
 }
 
 resource "azurerm_resource_provider_registration" "current" {

--- a/modules/single_integration/providers.tf
+++ b/modules/single_integration/providers.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.53.1"
+      version = "3.9.0"
     }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.53.1"
+      version = "3.9.0"
     }
   }
 }


### PR DESCRIPTION
## Jira
[INFL-20461](https://infralight1.atlassian.net/browse/INFL-20461)

## Change type
Code maintenance (dependency / provider version bump)

## What changed
- Bumped `hashicorp/azuread` from `2.53.1` → `3.9.0` in both `providers.tf` and `modules/single_integration/providers.tf`.
- Fixed the one breaking change in `modules/single_integration/data.tf`: the `azuread_service_principal` **data source** dropped the `application_id` argument in v3.0 — replaced with `client_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[INFL-20461]: https://infralight1.atlassian.net/browse/INFL-20461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ